### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/upload_dev.yml
+++ b/.github/workflows/upload_dev.yml
@@ -1,5 +1,8 @@
 name: Upload Dev zip
 
+permissions:
+  contents: read
+
 on:
   push:
     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/PacificITSupport/CIPP-API/security/code-scanning/2](https://github.com/PacificITSupport/CIPP-API/security/code-scanning/2)

Add an explicit `permissions` block in `.github/workflows/upload_dev.yml` at the workflow root (top-level, alongside `name` and `on`) so all jobs inherit minimal token scope.  
Best single fix without changing functionality: set:

- `contents: read`

This is sufficient for `actions/checkout@v4` and does not grant write scopes. No imports, methods, or definitions are needed (YAML config only).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
